### PR TITLE
Allow 'use' and 'install' commands to take sha1 argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,8 +43,22 @@ Examples:
 | Command | Description |
 | --- | --- |
 | `$ bazel install` | List all available releases |
-| `$ bazel install 0.8.0` | Install bazel release 0.8.0 |
-| `$ bazel install --list 0.8.0` | Show the assets bundled in install 0.8.0 |
+| `$ bazel install 0.24.1` | Install bazel release 0.24.1 |
+| `$ bazel install --assets 0.24.1` | Show the assets bundled in install 0.24.1 |
+
+To build bazel from source, specify a commit-id:
+
+```
+$ bazel install 9a32b861799278217c37eb32f864a951ca99617e
+(( bzl )) Install successful.  Remember to 'export BAZEL_VERSION=9a32b861799278217c37eb32f864a951ca99617e'
+```
+
+> The command above will clone bazel to
+> `$HOME/.cache/bzl/github.com/bazebuild/bazel`.  If you already have a version
+> of bazel installed that you'd rather use instead, specify
+> `--bazel_source_dir`. If you want to build & install from `bazel_source_dir`
+> directly (without changing to a specific commit), use `bazel install snapshot
+> --bazel_source_dir=/path/to/bazel` ().
 
 ### `$ bazel use`
 
@@ -84,6 +98,31 @@ $ bazel use rules_go
 0.17.4    Fri Apr 12 2019
 0.16.10   Fri Apr 12 2019
 0.18.2    Sat Apr 06 2019
+...
+```
+
+You can also specify a commit-id:
+
+```
+$ bazel use rules_go ef7cca8857f2f3a905b86c264737d0043c6a766e
+
+http_archive(
+    name = "io_bazel_rules_go",
+    urls = ["https://github.com/bazelbuild/rules_go/archive/ef7cca8857f2f3a905b86c264737d0043c6a766e.tar.gz"],
+    strip_prefix = "rules_go-ef7cca8857f2f3a905b86c264737d0043c6a766e",
+    sha256 = "1a400dc2f69971e3ebce29f7950dc38f8bb7e41c727258b6d2fb70060a4ce429",
+)
+```
+
+To list recent commits on a particular branch:
+
+```
+$ bazel use rules_go --history=master
+(( bzl )) 2019/04/29 06:36:48 Listing recent commit history for bazelbuild/rules_go...
+ef7cca8857f2f3a905b86c264737d0043c6a766e   Wed Apr 24 2019   bazel_test: fix load of generate_toolchain_names (#2040)
+56ecf4406adfd8917ac59ddd0ea008ff1d8f722a   Wed Apr 24 2019   Ensure bazel paths don't leak in stdlib builds (#1945)
+df1bb575ad1b35703e5b62fd0455907896c9eb32   Tue Apr 23 2019   update pin to bazel toolchains repo (#2038)
+528f6faf83f85c23da367d61f784893d1b3bd72b   Sat Apr 20 2019   GoCompilePkg: unified action for building a Go package (#2027)
 ...
 ```
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,11 +54,11 @@ go_repository(
     importpath = "github.com/davecgh/go-spew",
 )
 
-go_repository(
-    name = "com_golang_google_genproto",
-    commit = "3273178ea4684acc4f512f7bef7349dd72db88f6",
-    importpath = "google.golang.org/genproto",
-)
+# go_repository(
+#     name = "com_golang_google_genproto",
+#     commit = "3273178ea4684acc4f512f7bef7349dd72db88f6",
+#     importpath = "google.golang.org/genproto",
+# )
 
 go_repository(
     name = "com_github_gregjones_httpcache",

--- a/app.go
+++ b/app.go
@@ -76,7 +76,7 @@ func NewApp() *App {
 				if err != nil {
 					log.Fatalf("Invalid bazel version %s, aborting: %v", version, err)
 				}
-				err, exitCode := bazelutil.New().Invoke(args)
+				err, exitCode := bazelutil.New().Invoke(args, "")
 				if exitCode != 0 {
 					log.Printf("bazel exited with exitCode %d: %v", exitCode, err)
 					os.Exit(exitCode)
@@ -85,7 +85,7 @@ func NewApp() *App {
 		} else {
 			log.Println("BAZEL_VERSION not set, falling back to bazel on your PATH")
 			args = append(args, c.Args().Tail()...)
-			err, exitCode := bazelutil.New().Invoke(args)
+			err, exitCode := bazelutil.New().Invoke(args, "")
 			if exitCode != 0 {
 				log.Printf("bazel exited with exitCode %d: %v", exitCode, err)
 				os.Exit(exitCode)

--- a/command/install/BUILD.bazel
+++ b/command/install/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/bzl-io/bzl/command/install",
     visibility = ["//visibility:public"],
     deps = [
+        "//bazelutil:go_default_library",
         "//gh:go_default_library",
         "@com_github_dustin_go_humanize//:go_default_library",
         "@com_github_google_go_github//github:go_default_library",

--- a/command/release/release.go
+++ b/command/release/release.go
@@ -2,7 +2,6 @@ package release
 
 import (
 	"fmt"
-	"io"
 	"io/ioutil"
 	"log"
 	"net/http"
@@ -183,7 +182,7 @@ func copyFileToPlatformDir(c *cli.Context, assetDir string, platform string, fil
 	}
 	name += "-" + platformName
 	platformFile := path.Join(platformDir, name)
-	err = CopyFile(filename, platformFile)
+	err = bazelutil.CopyFile(filename, platformFile)
 	if err != nil {
 		return "", err
 	}
@@ -233,26 +232,6 @@ func processBuildEvent(event *bes.BuildEvent) error {
 		return fmt.Errorf("BuildEvent.Payload has unexpected type %T", x)
 	}
 	return nil
-}
-
-// https://gist.github.com/elazarl/5507969
-func CopyFile(src, dst string) error {
-	s, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	// no need to check errors on read only file, we already got everything
-	// we need from the filesystem, so nothing can go wrong now.
-	defer s.Close()
-	d, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	if _, err := io.Copy(d, s); err != nil {
-		d.Close()
-		return err
-	}
-	return d.Close()
 }
 
 func uploadRelease(c *cli.Context, files []string) (*github.RepositoryRelease, error) {


### PR DESCRIPTION
- install: add capability to build bazel from source.
- use: print http_archive for a commit-id.